### PR TITLE
update to allowed roles for area with no href

### DIFF
--- a/aria-usage.js
+++ b/aria-usage.js
@@ -807,7 +807,7 @@ var objElementRules = {
 	"areanohref": {
 		"nodeName": "area",
 		"nativeRole": null,
-		"allowedRoles": []
+		"allowedRoles": ["button", "link"]
 	},
 	"article": {
 		"nodeName": "article",


### PR DESCRIPTION
updates allowances per the ARIA in HTML PR - https://github.com/w3c/html-aria/pull/360

`area` without `href` can allow for `role=button` or `link`.