### PR TITLE
update allowances li and endnotes

### DIFF
--- a/aria-usage.js
+++ b/aria-usage.js
@@ -545,7 +545,7 @@ var objRoleRules = {
 	},
 	"doc-bibliography": {
 		"requiredParent": null,
-		"requiredChild": "doc-biblioentry",
+		"requiredChild": "list",
 		"requiredState": null,
 		"descendantRestrictions": null,
 		"supported": null
@@ -615,7 +615,7 @@ var objRoleRules = {
 	},
 	"doc-endnotes": {
 		"requiredParent": null,
-		"requiredChild": "doc-endnote",
+		"requiredChild": "list",
 		"requiredState": null,
 		"descendantRestrictions": null,
 		"supported": null
@@ -1197,7 +1197,7 @@ var objElementRules = {
 	"li": {
 		"nodeName": "li",
 		"nativeRole": "listitem",
-		"allowedRoles": ["menuitem", "menuitemcheckbox", "menuitemradio", "option", "none", "presentation", "radio", "separator", "tab", "treeitem", "doc-biblioentry", "doc-endnote"]
+		"allowedRoles": ["menuitem", "menuitemcheckbox", "menuitemradio", "option", "none", "presentation", "radio", "separator", "tab", "treeitem"]
 	},
 	"link": {
 		"nodeName": "link",

--- a/aria-usage.js
+++ b/aria-usage.js
@@ -607,7 +607,7 @@ var objRoleRules = {
 		"supported": null
 	},
 	"doc-endnote": {
-		"requiredParent": ["doc-endnotes", "list"],
+		"requiredParent": ["list"],
 		"requiredChild": null,
 		"requiredState": null,
 		"descendantRestrictions": null,

--- a/aria-usage.js
+++ b/aria-usage.js
@@ -1197,7 +1197,7 @@ var objElementRules = {
 	"li": {
 		"nodeName": "li",
 		"nativeRole": "listitem",
-		"allowedRoles": ["menuitem", "menuitemcheckbox", "menuitemradio", "option", "none", "presentation", "radio", "separator", "tab", "treeitem"]
+		"allowedRoles": ["menuitem", "menuitemcheckbox", "menuitemradio", "option", "none", "presentation", "radio", "separator", "tab", "treeitem", "doc-biblioentry", "doc-endnote"]
 	},
 	"link": {
 		"nodeName": "link",


### PR DESCRIPTION
the `doc-endnote` and `doc-biblioentry` are being deprecated in DPUB ARIA 1.1 as authors should be using standard list items instead.

* Removes allowances for these roles from the `<li>` element
* Updates requiredChild for `doc-bibliography` and `doc-endnotes` to be a `list`, and not the deprecated roles mentioned.

Open question @gezlemon, not sure what to do in regards to `doc-biblioentry` and `doc-endnote` entries specifically.  Remove them?  Mark them as "deprecated" in regards to "supported"?