### PR TITLE
adds missing allowance for role=radio on img alt=foo

### DIFF
--- a/aria-usage.js
+++ b/aria-usage.js
@@ -1062,7 +1062,7 @@ var objElementRules = {
 	"img": {
 		"nodeName": "imgWithAlt",
 		"nativeRole": "img",
-		"allowedRoles": ["button", "checkbox", "link", "menuitem", "menuitemcheckbox", "menuitemradio", "option", "progressbar", "scrollbar", "separator", "slider", "switch", "tab", "treeitem"]
+		"allowedRoles": ["button", "checkbox", "link", "menuitem", "menuitemcheckbox", "menuitemradio", "option", "progressbar", "radio", "scrollbar", "separator", "slider", "switch", "tab", "treeitem"]
 	},
 	"input-button": {
 		"nodeName": "input",


### PR DESCRIPTION
related to ARIA in HTML PR https://github.com/w3c/html-aria/pull/212, `role=radio` was meant to be kept as an allowance for an `img` with an accessible name, but it didn't make it into the spec.  

https://github.com/w3c/html-aria/pull/381 will add this allowance.  This PR adds this allowance.