### PR TITLE
allows role=combobox on button and input type=button

### DIFF
--- a/aria-usage.js
+++ b/aria-usage.js
@@ -864,7 +864,7 @@ var objElementRules = {
 	"button": {
 		"nodeName": "button",
 		"nativeRole": "button",
-		"allowedRoles": ["checkbox", "link", "menuitem", "menuitemcheckbox", "menuitemradio", "option", "radio", "switch", "tab"]
+		"allowedRoles": ["checkbox", "combobox", "link", "menuitem", "menuitemcheckbox", "menuitemradio", "option", "radio", "switch", "tab"]
 	},
 	"canvas": {
 		"nodeName": "canvas",
@@ -1069,7 +1069,7 @@ var objElementRules = {
 	"input-button": {
 		"nodeName": "input",
 		"nativeRole": "button",
-		"allowedRoles": ["link", "menuitem", "menuitemcheckbox", "menuitemradio", "option", "radio", "switch", "tab"]
+		"allowedRoles": ["checkbox", "combobox", "link", "menuitem", "menuitemcheckbox", "menuitemradio", "option", "radio", "switch", "tab"]
 	},
 	"input-checkbox": {
 		"nodeName": "input",


### PR DESCRIPTION
This PR addresses [ARIA in HTML](https://github.com/w3c/html-aria/pull/396) being updated to allow the `combobox` role on these elements, and fix an oversight where `role=checkbox` should have been allowed on `input type=button` to match the same allowance on the `button` element.